### PR TITLE
Widen peerDependencies to allow React v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17",
+    "react-dom": "^16.0.0 || ^17"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",


### PR DESCRIPTION
To avoid warnings when running `npm install` in a project that uses React v17, this widens the versions of `react` and `react-dom` allowed by `peerDependencies` to include v17.

The `devDependencies` section is already using React v17, so I assume everything works correctly.